### PR TITLE
extend index encoding table

### DIFF
--- a/pkg/oelf/OELFGenDynlibData.go
+++ b/pkg/oelf/OELFGenDynlibData.go
@@ -37,7 +37,7 @@ const (
 	_nidSuffixKey = "518D64A635DED8C1E6B039B1C3E55230"
 
 	// _indexEncodingTable provides the encoding table for module indices that are appended to the end of NIDs.
-	_indexEncodingTable = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	_indexEncodingTable = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-"
 )
 
 // _moduleToLibDictionary contains a mapping of module names to library (prx) paths


### PR DESCRIPTION
allows for more than 26 libraries to be imported, these extended values have been determined and verified by looking at games with large import tables by multiple parties (kiwi can vouch for the correctness)